### PR TITLE
Refactor

### DIFF
--- a/src/EventsContract.ts
+++ b/src/EventsContract.ts
@@ -4,12 +4,13 @@ import {
   state,
   State,
   method,
-  MerkleMap,
   UInt32,
+  MerkleTree,
+  MerkleWitness,
 } from 'snarkyjs';
 import { PostsProof } from './Posts';
 
-const postsTree = new MerkleMap();
+const postsTree = new MerkleTree(10);
 const postsRoot = postsTree.getRoot();
 
 export class EventsContract extends SmartContract {


### PR DESCRIPTION
- Refactor to use MerkleTree indexes to order posts
- Include the public addresses of posters and IPFS Content Identifiers of posts as properties in the posts states