### PR TITLE
Merge dev

### DIFF
--- a/src/EventsContract.ts
+++ b/src/EventsContract.ts
@@ -6,7 +6,6 @@ import {
   method,
   UInt32,
   MerkleTree,
-  MerkleWitness,
 } from 'snarkyjs';
 import { PostsProof } from './Posts';
 
@@ -15,12 +14,12 @@ const postsRoot = postsTree.getRoot();
 
 export class EventsContract extends SmartContract {
   @state(Field) posts = State<Field>();
-  @state(Field) postsNumber = State<Field>();
+  @state(Field) numberOfPosts = State<Field>();
 
   init() {
     super.init();
     this.posts.set(postsRoot);
-    this.postsNumber.set(Field(0));
+    this.numberOfPosts.set(Field(0));
   }
 
   @method update(rollupProof: PostsProof) {
@@ -34,10 +33,12 @@ export class EventsContract extends SmartContract {
     const currentState = this.posts.getAndAssertEquals();
     rollupProof.publicInput.initialPostsRoot.assertEquals(currentState);
 
-    const currentPostsNumber = this.postsNumber.getAndAssertEquals();
-    rollupProof.publicInput.initialPostsNumber.assertEquals(currentPostsNumber);
+    const currentPostsNumber = this.numberOfPosts.getAndAssertEquals();
+    rollupProof.publicInput.initialNumberOfPosts.assertEquals(
+      currentPostsNumber
+    );
 
     this.posts.set(rollupProof.publicInput.latestPostsRoot);
-    this.postsNumber.set(rollupProof.publicInput.latestPostsNumber);
+    this.numberOfPosts.set(rollupProof.publicInput.latestNumberOfPosts);
   }
 }

--- a/src/Posts.test.ts
+++ b/src/Posts.test.ts
@@ -74,7 +74,6 @@ describe(`the 'EventsContract' and the 'Posts' zkProgram`, () => {
       posterAddress: posterAddress,
       postContentID: postContentID,
       postedAtBlockHeight: postedAtBlockHeight,
-      deletedPost: Bool(false),
       deletedAtBlockHeight: Field(0),
     });
 
@@ -109,7 +108,6 @@ describe(`the 'EventsContract' and the 'Posts' zkProgram`, () => {
       posterAddress: initialPostState.posterAddress,
       postContentID: initialPostState.postContentID,
       postedAtBlockHeight: initialPostState.postedAtBlockHeight,
-      deletedPost: Bool(true),
       deletedAtBlockHeight: deletionBlockHeight,
     });
 
@@ -283,7 +281,6 @@ describe(`the 'EventsContract' and the 'Posts' zkProgram`, () => {
       posterAddress: deployerAccount,
       postContentID: valid.postState.postContentID,
       postedAtBlockHeight: valid.postState.postedAtBlockHeight,
-      deletedPost: valid.postState.deletedPost,
       deletedAtBlockHeight: valid.postState.deletedAtBlockHeight,
     });
 
@@ -317,7 +314,6 @@ describe(`the 'EventsContract' and the 'Posts' zkProgram`, () => {
         'bduuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuaaaaaaaaaaaaaaaaaaaaaaaaaa'
       ),
       postedAtBlockHeight: valid.postState.postedAtBlockHeight,
-      deletedPost: valid.postState.deletedPost,
       deletedAtBlockHeight: valid.postState.deletedAtBlockHeight,
     });
 
@@ -421,7 +417,6 @@ describe(`the 'EventsContract' and the 'Posts' zkProgram`, () => {
       posterAddress: valid.postState.posterAddress,
       postContentID: valid.postState.postContentID,
       postedAtBlockHeight: Field(849),
-      deletedPost: valid.postState.deletedPost,
       deletedAtBlockHeight: valid.postState.deletedAtBlockHeight,
     });
 
@@ -825,7 +820,6 @@ describe(`the 'EventsContract' and the 'Posts' zkProgram`, () => {
         'bduuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuaaaaaaaaaaaaaaaaaaaaaaaaaa'
       ),
       postedAtBlockHeight: valid1.postState.postedAtBlockHeight,
-      deletedPost: valid1.postState.deletedPost,
       deletedAtBlockHeight: valid1.postState.deletedAtBlockHeight,
     });
 

--- a/src/Posts.ts
+++ b/src/Posts.ts
@@ -25,7 +25,6 @@ export class PostState extends Struct({
   posterAddress: PublicKey,
   postContentID: CircuitString,
   postedAtBlockHeight: Field,
-  deletedPost: Bool,
   deletedAtBlockHeight: Field,
 }) {
   hash(): Field {
@@ -35,7 +34,6 @@ export class PostState extends Struct({
         .concat([
           this.postContentID.hash(),
           this.postedAtBlockHeight,
-          this.deletedPost.toField(),
           this.deletedAtBlockHeight,
         ])
     );
@@ -71,7 +69,6 @@ export class PostsTransition extends Struct({
     initialPostsRoot.assertEquals(postsRootBefore);
 
     initialPostsNumber.assertEquals(postIndex.sub(1));
-    postState.deletedPost.assertFalse();
     postState.deletedAtBlockHeight.assertEquals(Field(0));
 
     const postsRootAfter = postWitness.calculateRoot(postState.hash());
@@ -139,7 +136,6 @@ export class PostsTransition extends Struct({
       posterAddress: initialPostState.posterAddress,
       postContentID: initialPostState.postContentID,
       postedAtBlockHeight: initialPostState.postedAtBlockHeight,
-      deletedPost: Bool(true),
       deletedAtBlockHeight: blockHeight,
     });
 


### PR DESCRIPTION
- Remove redundant 'deletedPost' property from PostState (deletion of post is already indicated by 'deletedAtBlockHeight' property being set different to its default value
- Require index of post in signature to avoid signature reuse
- Include indexes of posts as a 'PostState' property, to make the hash of 'PostState' unique even if the same user posts the same content more than once
- Rename some variables